### PR TITLE
refactor: remove --no-save and --once options to simplify codebase

### DIFF
--- a/ccmonitor/process.py
+++ b/ccmonitor/process.py
@@ -57,7 +57,7 @@ def find_claude_processes() -> list[ProcessInfo]:
     return claude_processes
 
 
-def is_claude_process(name: str, cmdline: list[str]) -> bool:  # noqa: ARG001
+def is_claude_process(name: str, cmdline: list[str]) -> bool:
     """Determine if a process is related to Claude Code.
 
     Args:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,18 +50,6 @@ def test_main_history(mock_db_class) -> None:
     # Should not call find_claude_processes for history mode
 
 
-@patch("ccmonitor.__main__.RealTimeMonitor")
-def test_main_no_save(mock_monitor_class) -> None:
-    """Test main command with --no-save flag."""
-    mock_monitor = Mock()
-    mock_monitor_class.return_value = mock_monitor
-
-    runner = CliRunner()
-    result = runner.invoke(main, ["--no-save"])
-    assert result.exit_code == 0
-    # Should create monitor with no database
-    mock_monitor_class.assert_called_once_with(db=None, update_interval=1.0)
-    mock_monitor.run.assert_called_once()
 
 
 def test_main_help() -> None:
@@ -72,33 +60,8 @@ def test_main_help() -> None:
     assert "Claude Code Monitor" in result.output
 
 
-@patch("ccmonitor.__main__.ProcessDatabase")
-@patch("ccmonitor.__main__.find_claude_processes")
-def test_main_exception_handling(mock_find_processes, mock_db_class) -> None:
-    """Test error handling in main function."""
-    mock_find_processes.side_effect = Exception("Test error")
-    mock_db_class.return_value = Mock()
-
-    runner = CliRunner()
-    result = runner.invoke(main, ["--once"])
-    assert result.exit_code == 0
-    assert "❌ Error: Test error" in result.output
 
 
-@patch("ccmonitor.__main__.ProcessDatabase")
-@patch("ccmonitor.__main__.find_claude_processes")
-def test_main_once_flag(mock_find_processes, mock_db_class) -> None:
-    """Test main command with --once flag."""
-    mock_find_processes.return_value = []
-    mock_db = Mock()
-    mock_db_class.return_value = mock_db
-
-    runner = CliRunner()
-    result = runner.invoke(main, ["--once"])
-    assert result.exit_code == 0
-    assert "No Claude Code processes found" in result.output
-    # save_processes is not called when no processes are found
-    mock_db.save_processes.assert_not_called()
 
 
 @patch("ccmonitor.__main__.ProcessDatabase")
@@ -134,23 +97,5 @@ def test_main_realtime_with_interval(mock_monitor_class, mock_db_class) -> None:
     mock_monitor_class.assert_called_once_with(db=mock_db, update_interval=2.5)
 
 
-@patch("ccmonitor.__main__.RealTimeMonitor")
-def test_main_realtime_no_save(mock_monitor_class) -> None:
-    """Test main command with --no-save in real-time mode."""
-    mock_monitor = Mock()
-    mock_monitor_class.return_value = mock_monitor
-
-    runner = CliRunner()
-    runner.invoke(main, ["--no-save"])
-
-    # Should create monitor with no database
-    mock_monitor_class.assert_called_once_with(db=None, update_interval=1.0)
 
 
-def test_main_history_with_no_save() -> None:
-    """Test that --history and --no-save together raises an error."""
-    runner = CliRunner()
-    result = runner.invoke(main, ["--history", "--no-save"])
-
-    assert result.exit_code == 0
-    assert "--historyオプションは--no-saveと一緒に使用できません" in result.output


### PR DESCRIPTION
## Summary
- `--no-save`と`--once`オプションを削除してコードベースをコンパクトにしました
- メイン関数のロジックを簡素化し、常にデータベースを使用するようにしました
- 削除されたオプションに関連するテストケースを削除しました
- 未使用のインポートを削除してリントエラーを修正しました

## Changes Made
- `ccmonitor/__main__.py`: `--no-save`と`--once`オプションの定義と実装を削除
- `tests/test_main.py`: 削除されたオプションに関連するテストケースを削除
- `ccmonitor/process.py`: 未使用の`noqa`ディレクティブを削除

## Test Results
- 全てのテスト（41件）が正常に実行されました
- リントエラーは修正されました
- コードフォーマットは適用されました

## Impact
- コードベースがよりシンプルになり、保守性が向上しました
- 削除されたオプションに依存していた機能はありません
- データベースの使用は常に有効になります

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified command-line interface by removing the options for disabling saving and single-run mode.
- **Refactor**
	- Streamlined process monitoring behavior for consistency and easier usage.
- **Tests**
	- Removed tests related to the discontinued options and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->