### PR TITLE
Fix header display to show correct time unit based on option used

### DIFF
--- a/ccmonitor/timeline_monitor.py
+++ b/ccmonitor/timeline_monitor.py
@@ -57,7 +57,7 @@ class TimelineMonitor:
             self.console.clear()
 
             # Display components separately for better control
-            self.ui.display_timeline(timelines, start_time, end_time)
+            self.ui.display_timeline(timelines, start_time, end_time, time_unit)
 
         except Exception as e:
             self.console.print(f"[red]Error loading sessions: {e}[/red]")

--- a/ccmonitor/timeline_ui.py
+++ b/ccmonitor/timeline_ui.py
@@ -17,16 +17,17 @@ class TimelineUI:
         """Initialize the timeline UI."""
         self.console = Console()
 
-    def display_timeline(self, timelines: list[SessionTimeline], start_time: datetime, end_time: datetime) -> None:
+    def display_timeline(self, timelines: list[SessionTimeline], start_time: datetime, end_time: datetime, time_unit: str) -> None:
         """Display the timeline components directly to console.
 
         Args:
             timelines: List of session timelines to display
             start_time: Start of the time range
             end_time: End of the time range
+            time_unit: Time unit description (e.g., "2 days", "6 hours")
         """
         # Header
-        header_panel = self._create_header(start_time, end_time, len(timelines))
+        header_panel = self._create_header(start_time, end_time, len(timelines), time_unit)
         self.console.print(header_panel)
 
         # Main content with timeline visualization
@@ -44,18 +45,15 @@ class TimelineUI:
             summary_text = self.create_summary_text(timelines)
             self.console.print(summary_text)
 
-    def _create_header(self, start_time: datetime, end_time: datetime, session_count: int) -> Panel:
+    def _create_header(self, start_time: datetime, end_time: datetime, session_count: int, time_unit: str) -> Panel:
         """Create header panel with title and time range info."""
-        duration = end_time - start_time
-        hours = int(duration.total_seconds() / 3600)
-
         header_text = Text.assemble(
             ("📊 Claude Project Timeline", "bold cyan"),
             " | ",
             (start_time.strftime("%m/%d/%Y %H:%M")),
             " - ",
             (end_time.strftime("%m/%d/%Y %H:%M")),
-            (f" ({hours} hours)", "bold"),
+            (f" ({time_unit})", "bold"),
             " | ",
             (f"{session_count} projects", "yellow"),
         )

--- a/tests/test_timeline_ui.py
+++ b/tests/test_timeline_ui.py
@@ -57,7 +57,7 @@ class TestTimelineUI:
         end_time = datetime(2024, 1, 1, 14, 0, 0)
         session_count = 3
 
-        header = timeline_ui._create_header(start_time, end_time, session_count)
+        header = timeline_ui._create_header(start_time, end_time, session_count, "4 hours")
 
         assert header is not None
         assert header.border_style == "blue"
@@ -258,7 +258,7 @@ class TestTimelineUI:
 
         with patch.object(timeline_ui.console, "print") as mock_print:
             # Should not raise any exceptions
-            timeline_ui.display_timeline(timelines, start_time, end_time)
+            timeline_ui.display_timeline(timelines, start_time, end_time, "1 day")
 
             # Verify console.print was called
             assert mock_print.called
@@ -269,7 +269,7 @@ class TestTimelineUI:
         end_time = start_time + timedelta(hours=1)
 
         with patch.object(timeline_ui.console, "print") as mock_print:
-            timeline_ui.display_timeline([], start_time, end_time)
+            timeline_ui.display_timeline([], start_time, end_time, "1 hour")
 
             # Should print "no sessions found" message
             assert mock_print.called


### PR DESCRIPTION
## Summary
- Fix header display to show "X days" when --days option is used
- Fix header display to show "X hours" when --hours option is used
- Previously, header always showed hours regardless of which option was used

## Changes
- Modified `timeline_monitor.py` to pass `time_unit` string to UI layer
- Updated `timeline_ui.py` to accept and display `time_unit` parameter in header
- Fixed failing tests by adding missing `time_unit` parameter

## Test plan
- [x] Test --days option shows "2 days" in header
- [x] Test --hours option shows "6 hours" in header  
- [x] All timeline_ui tests pass
- [x] Manual verification of both options

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline headers now display a more descriptive time range label (e.g., "2 days", "6 hours") for improved clarity.

* **Bug Fixes**
  * Timeline display now accurately reflects the provided time range label in the header.

* **Tests**
  * Updated tests to verify correct handling and display of the new time range label in timeline headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->