### PR TITLE
Improve duration calculation by adjusting inactive threshold

### DIFF
--- a/ccmonitor/claude_logs.py
+++ b/ccmonitor/claude_logs.py
@@ -137,7 +137,7 @@ def calculate_active_duration(events: list[SessionEvent]) -> int:
     sorted_events = sorted(events, key=lambda e: e.timestamp)
 
     active_minutes = 0
-    inactive_threshold = 1  # 1 minute threshold for inactive periods
+    inactive_threshold = 3  # 3 minute threshold for inactive periods
 
     for i in range(1, len(sorted_events)):
         prev_event = sorted_events[i - 1]

--- a/tests/test_claude_logs.py
+++ b/tests/test_claude_logs.py
@@ -109,7 +109,7 @@ class TestCalculateActiveDuration:
         assert duration == 1
 
     def test_with_inactive_periods(self):
-        """Test active duration with inactive periods (intervals > 1 minute)."""
+        """Test active duration with inactive periods (intervals > 3 minutes)."""
         base_time = datetime.now()
         events = []
 
@@ -135,11 +135,11 @@ class TestCalculateActiveDuration:
             )
         )
 
-        # Long gap (3 minutes - exceeds 1-minute threshold)
+        # Long gap (4 minutes - exceeds 3-minute threshold)
         # Second cluster: 2 events 45 seconds apart
         events.append(
             SessionEvent(
-                timestamp=base_time + timedelta(minutes=3, seconds=30),
+                timestamp=base_time + timedelta(minutes=4, seconds=30),
                 session_id="test",
                 directory="/test",
                 message_type="user",
@@ -149,7 +149,7 @@ class TestCalculateActiveDuration:
         )
         events.append(
             SessionEvent(
-                timestamp=base_time + timedelta(minutes=4, seconds=15),
+                timestamp=base_time + timedelta(minutes=5, seconds=15),
                 session_id="test",
                 directory="/test",
                 message_type="assistant",
@@ -159,7 +159,7 @@ class TestCalculateActiveDuration:
         )
 
         duration = calculate_active_duration(events)
-        # Only intervals <= 1 minute: 0.5 + 0.75 = 1.25 minutes
+        # Only intervals <= 3 minutes: 0.5 + 0.75 = 1.25 minutes
         assert duration == 1
 
     def test_empty_events(self):


### PR DESCRIPTION
## Summary
- Improve duration calculation accuracy by changing inactive threshold from 1 minute to 3 minutes
- Previous 1-minute threshold was too restrictive for Claude Code sessions
- Users need time to read code, think, and plan their approach between interactions

## Problem
Current duration calculations were unrealistically short:
- 357 events showing only 14 minutes of activity
- 2576 events showing only 120 minutes of activity

## Solution  
- Increase inactive threshold from 1 minute to 3 minutes
- Better reflects real Claude Code usage patterns where users pause to think, read, and plan

## Results
More realistic duration calculations:
- 357 events: 14m → 33m (2.4x improvement)
- 2576 events: 120m → 159m (1.3x improvement)

## Changes
- Modified `calculate_active_duration()` in `claude_logs.py`
- Updated test cases to reflect new 3-minute threshold
- All existing tests pass with updated expectations

## Test plan
- [x] All duration calculation tests pass
- [x] Manual verification with real session data shows improved accuracy
- [x] Duration calculations are now more realistic for Claude Code sessions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session activity tracking by increasing the inactivity threshold from 1 minute to 3 minutes, resulting in more accurate calculation of active durations.

* **Tests**
  * Updated test cases and documentation to align with the new 3-minute inactivity threshold for session activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->