### PR TITLE
Fix worktree option project grouping

### DIFF
--- a/cmd/ccmonitor/main.go
+++ b/cmd/ccmonitor/main.go
@@ -16,6 +16,7 @@ var (
 	hours    int
 	project  string
 	worktree bool
+	debug    bool
 )
 
 var rootCmd = &cobra.Command{
@@ -34,6 +35,7 @@ func init() {
 	rootCmd.Flags().IntVarP(&hours, "hours", "t", 0, "Number of hours to look back (1-24, overrides --days)")
 	rootCmd.Flags().StringVarP(&project, "project", "p", "", "Filter by specific project")
 	rootCmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Show projects as worktree (separate similar repos)")
+	rootCmd.Flags().BoolVar(&debug, "debug", false, "Enable debug output for troubleshooting")
 }
 
 func runMonitor() error {
@@ -61,7 +63,7 @@ func runMonitor() error {
 	fmt.Println(loadingMsg)
 
 	// Load sessions
-	timelines, err := claude.LoadSessionsInTimeRange(startTime, endTime, project, worktree)
+	timelines, err := claude.LoadSessionsInTimeRange(startTime, endTime, project, worktree, debug)
 	if err != nil {
 		return fmt.Errorf("failed to load sessions: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Fix issue where worktree option (-w) was not correctly grouping projects by git repository
- Projects from same repository like rust-ratatui-rei... now correctly appear under ccmonitor parent project

## Changes
- Implement proper logic for `threads` parameter in `groupEventsByProject()`
- Add `groupEventsByRepository()` for default mode (groups by git repository)
- Add `groupEventsByDirectory()` for worktree mode (groups by directory)
- When worktree=false (default): Projects grouped by git repository with parent-child relationships
- When worktree=true: Projects displayed separately by directory

## Test Plan
- [x] Test default mode (`./bin/ccmonitor --days 7`) - shows repository grouping with parent-child relationships
- [x] Test worktree mode (`./bin/ccmonitor --days 7 --worktree`) - shows directory-based grouping
- [x] Verify rust-ratatui-rei... and similar projects now appear under correct parent repository

## Before/After
**Before**: rust-ratatui-rei... appeared as separate project  
**After**: rust-ratatui-rei... appears under ccmonitor with proper indentation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced grouping of session events by git repository with consolidated and hierarchical views.
  * Added hierarchical project timelines for multi-directory repositories, showing parent and child timelines.
  * Added a debug mode toggle via a new command-line flag for enhanced troubleshooting output.

* **Enhancements**
  * Improved timeline sorting by event count, ensuring parent timelines appear before child timelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->