### PR TITLE
feat: Implement flexible table column widths with min/max constraints

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -122,7 +122,7 @@ func (ui *TimelineUI) createTimelineTable(timelines []*models.SessionTimeline, s
 	// Calculate column widths with min/max constraints
 	const (
 		projectMinWidth  = 15
-		projectMaxWidth  = 30
+		projectMaxWidth  = 35  // Increased from 30 to 35
 		timelineMinWidth = 25
 		timelineMaxWidth = 80
 		eventsWidth      = 8
@@ -207,7 +207,7 @@ func (ui *TimelineUI) createTimelineTable(timelines []*models.SessionTimeline, s
 			projectDisplay = " └─" + timeline.ProjectName
 		}
 
-		projectDisplay = truncate.StringWithTail(projectDisplay, uint(projectWidth-2), "…")
+		projectDisplay = truncate.StringWithTail(projectDisplay, uint(projectWidth), "…")
 
 		t.Row(projectDisplay, timelineStr, fmt.Sprintf("%d", len(timeline.Events)), durationStr)
 	}


### PR DESCRIPTION
## Summary
- テーブルのproject列とtimeline列の幅を固定幅から最小幅・最大幅指定に変更
- プロジェクト名の長さに基づいて動的に列幅を計算する機能を追加
- ターミナルサイズや表示内容に応じてより柔軟なレイアウトを実現

## 主な変更内容
- `calculateOptimalProjectWidth`関数を追加してプロジェクト名の長さに基づく最適な列幅を計算
- プロジェクト列: 固定20文字 → 15-30文字の範囲で動的調整
- タイムライン列: 最小25文字・最大80文字の制約を追加
- タイムライン列が最大幅に達した場合、プロジェクト列の幅を再計算して空間を有効活用

## Test plan
- [x] ビルドが成功することを確認
- [x] 短いプロジェクト名と長いプロジェクト名で表示確認
- [x] 異なるターミナルサイズでのレイアウト動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project column width in the timeline table now adjusts dynamically based on project name length and hierarchy, improving readability.
* **Improvements**
  * Maximum project column width increased for better display of longer names.
  * Truncation of project names now aligns with the dynamically calculated column width for more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->