### PR TITLE
fix: remove Windows support from release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ jobs:
         # Linux arm64
         GOOS=linux GOARCH=arm64 go build -o ccmonitor-linux-arm64 ./cmd/ccmonitor
         
-        # Windows amd64
-        GOOS=windows GOARCH=amd64 go build -o ccmonitor-windows-amd64.exe ./cmd/ccmonitor
-        
         # macOS amd64
         GOOS=darwin GOARCH=amd64 go build -o ccmonitor-darwin-amd64 ./cmd/ccmonitor
         
@@ -39,7 +36,6 @@ jobs:
         files: |
           ccmonitor-linux-amd64
           ccmonitor-linux-arm64
-          ccmonitor-windows-amd64.exe
           ccmonitor-darwin-amd64
           ccmonitor-darwin-arm64
         generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ wget https://github.com/ktny/ccstat/releases/download/v0.1.0/ccstat-v0.1.0-darwi
 chmod +x ccstat-v0.1.0-darwin-amd64
 sudo mv ccstat-v0.1.0-darwin-amd64 /usr/local/bin/ccstat
 
-# Windows (PowerShell)
-Invoke-WebRequest -Uri "https://github.com/ktny/ccstat/releases/download/v0.1.0/ccstat-v0.1.0-windows-amd64.exe" -OutFile "ccstat.exe"
 ```
 
 ### Option 2: Go Install (Latest Stable)
@@ -130,6 +128,12 @@ ccstat --days 3 --project ccstat --worktree
 - **Go 1.21+** for building from source
 - **Claude Code** for generating session logs
 - **Git** (recommended) for project integration features
+
+## 🖥️ Supported Platforms
+
+- Linux (x86_64, ARM64)
+- macOS (Intel, Apple Silicon)
+- **Note**: Windows is not currently supported
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary
- Remove Windows build configuration from GitHub Actions release workflow
- Remove Windows installation instructions from README
- Add supported platforms section to clarify Linux and macOS only support

## Test plan
- [ ] GitHub Actions workflow validation (no Windows build)
- [ ] README documentation review

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Windows binary from release process and updated supported platforms.
* **Documentation**
  * Updated README to remove Windows installation instructions and clarify supported platforms (Linux and macOS only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->