### PR TITLE
Adjust inactive threshold to 5 minutes with minimum active time

### DIFF
--- a/internal/claude/parser.go
+++ b/internal/claude/parser.go
@@ -163,7 +163,7 @@ func LoadSessionsInTimeRange(startTime, endTime time.Time, projectFilter string,
 	if debug {
 		fmt.Printf("DEBUG: Repository cache cleared\n")
 	}
-	
+
 	var allEvents []*models.SessionEvent
 
 	// Get all JSONL files
@@ -239,7 +239,7 @@ func CalculateActiveDuration(events []*models.SessionEvent) int {
 	})
 
 	activeMinutes := 0.0
-	inactiveThreshold := 3.0 // 3 minute threshold for inactive periods
+	inactiveThreshold := 5.0 // 5 minute threshold for inactive periods
 
 	for i := 1; i < len(events); i++ {
 		prevEvent := events[i-1]
@@ -250,10 +250,16 @@ func CalculateActiveDuration(events []*models.SessionEvent) int {
 		// Only count intervals up to the threshold as active time
 		if intervalMinutes <= inactiveThreshold {
 			activeMinutes += intervalMinutes
+		} else {
+			// If interval is longer than threshold, still count 1 minute as active
+			// (represents the minimum active time before becoming inactive)
+			activeMinutes += 1.0
 		}
-		// If interval is longer than threshold, don't add any time
-		// (this represents an inactive period)
 	}
+
+	// Add 1 minute for the last event (similar logic - even if no subsequent activity,
+	// we assume 1 minute of active work for the last message)
+	activeMinutes += 1.0
 
 	return int(activeMinutes)
 }

--- a/internal/claude/parser_test.go
+++ b/internal/claude/parser_test.go
@@ -128,3 +128,35 @@ func BenchmarkParseFilesParallel(b *testing.B) {
 		_ = parseFilesInParallel(jsonlFiles, startTime, false)
 	}
 }
+
+func BenchmarkGroupEventsByRepositoryConsolidated(b *testing.B) {
+	// Create test events for benchmarking
+	var events []*models.SessionEvent
+
+	// Simulate many events from the same directory (realistic scenario)
+	for i := 0; i < 1000; i++ {
+		event := &models.SessionEvent{
+			Timestamp:   time.Now().Add(time.Duration(i) * time.Minute),
+			Directory:   "/home/test/project1", // Same directory for all events
+			MessageType: "assistant",
+		}
+		events = append(events, event)
+	}
+
+	// Add some events from different directories
+	for i := 0; i < 100; i++ {
+		event := &models.SessionEvent{
+			Timestamp:   time.Now().Add(time.Duration(i) * time.Minute),
+			Directory:   "/home/test/project2",
+			MessageType: "user",
+		}
+		events = append(events, event)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Clear cache between runs for consistent benchmarking
+		repositoryCache = make(map[string]string)
+		_, _ = groupEventsByRepositoryConsolidated(events, false)
+	}
+}


### PR DESCRIPTION
## Summary
- inactiveThresholdを3分から5分に変更
- 5分以上の間隔がある場合でも、最低1分間はactiveとして計算
- 最後のメッセージについても1分間のactive時間を追加
- より正確な作業時間計算を実現

## Changes Made
- `CalculateActiveDuration` 関数の修正：
  - `inactiveThreshold` を3.0から5.0に変更
  - inactive期間（5分超）でも1分間はactiveとして加算
  - 最後のイベントに対して1分間のactive時間を追加

## Test Plan
- [x] ビルドが成功することを確認
- [x] 既存のテストが通ることを確認
- [x] 実際の実行で期待される動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Repository name lookups are now cached, resulting in faster event grouping and reduced redundant operations.
  * Improved efficiency when grouping events by repository, especially for large numbers of events.

* **Enhancements**
  * Active duration calculation now uses a longer inactivity threshold (5 minutes) and ensures minimal active time is counted for longer gaps and the last event.

* **Tests**
  * Added a benchmark to measure the performance of event grouping by repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->