### PR TITLE
Adjust inactive threshold to 5 minutes with minimum active time

### DIFF
--- a/internal/claude/parser.go
+++ b/internal/claude/parser.go
@@ -233,7 +233,7 @@ func CalculateActiveDuration(events []*models.SessionEvent) int {
 	})
 
 	activeMinutes := 0.0
-	inactiveThreshold := 3.0 // 3 minute threshold for inactive periods
+	inactiveThreshold := 5.0 // 5 minute threshold for inactive periods
 
 	for i := 1; i < len(events); i++ {
 		prevEvent := events[i-1]
@@ -244,10 +244,16 @@ func CalculateActiveDuration(events []*models.SessionEvent) int {
 		// Only count intervals up to the threshold as active time
 		if intervalMinutes <= inactiveThreshold {
 			activeMinutes += intervalMinutes
+		} else {
+			// If interval is longer than threshold, still count 1 minute as active
+			// (represents the minimum active time before becoming inactive)
+			activeMinutes += 1.0
 		}
-		// If interval is longer than threshold, don't add any time
-		// (this represents an inactive period)
 	}
+
+	// Add 1 minute for the last event (similar logic - even if no subsequent activity,
+	// we assume 1 minute of active work for the last message)
+	activeMinutes += 1.0
 
 	return int(activeMinutes)
 }


### PR DESCRIPTION
## Summary
- inactiveThresholdを3分から5分に変更
- 5分以上の間隔がある場合でも、最低1分間はactiveとして計算
- 最後のメッセージについても1分間のactive時間を追加
- より正確な作業時間計算を実現

## Changes Made
- `CalculateActiveDuration` 関数の修正：
  - `inactiveThreshold` を3.0から5.0に変更
  - inactive期間（5分超）でも1分間はactiveとして加算
  - 最後のイベントに対して1分間のactive時間を追加

## Test Plan
- [x] ビルドが成功することを確認
- [x] 既存のテストが通ることを確認
- [x] mainブランチからクリーンなブランチで作成

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calculation of active work duration by extending the inactivity threshold from 3 to 5 minutes and ensuring minimal active time is counted for longer gaps and the final event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->