### PR TITLE
fix: add trailing newline when no sessions found

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -101,6 +101,7 @@ func (ui *TimelineUI) DisplayTimeline(timelines []*models.SessionTimeline, start
 			BorderForeground(lipgloss.Color("11")).
 			Render(noSessionsText)
 		output.WriteString(noSessionsPanel)
+		output.WriteString("\n")
 		return output.String()
 	}
 


### PR DESCRIPTION
## Summary
- Fixed an issue where shell prompt indicator (%) appeared after "No Claude sessions found" message
- Added trailing newline to ensure proper output formatting when no sessions are found

## Test plan
- [x] Build ccstat with `make build`
- [x] Run `./bin/ccstat --days 0` to test with no sessions
- [x] Verify that no trailing `%` appears after the message
- [x] Confirm proper formatting of the output

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display formatting by ensuring a newline is added after the "no sessions" panel when no timelines are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->