### PR TITLE
fix: remove --project flag due to bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,14 +45,8 @@ make install
 # or using short option
 ./bin/ccstat -H 6
 
-# Filter display by specific project
-./bin/ccstat --project myproject
-
 # Worktree display (separate directories within the same repository)
 ./bin/ccstat --worktree
-
-# Multiple option combinations
-./bin/ccstat --days 3 --project myproject --worktree
 
 # Using Makefile shortcuts
 make run        # Build and run with defaults
@@ -114,7 +108,7 @@ ccstat/
 
 #### cmd/ccstat/main.go - CLI Entry Point
 - Uses Cobra for CLI argument parsing
-- Handles flags: --days, --hours, --project, --worktree, --version, --debug
+- Handles flags: --days, --hours, --worktree, --version, --debug
 - Orchestrates the main data flow: parse CLI → load sessions → create UI → display
 
 #### internal/claude/parser.go - Log Analysis Engine

--- a/cmd/ccstat/main.go
+++ b/cmd/ccstat/main.go
@@ -22,7 +22,6 @@ var (
 	// CLI flags
 	days            int
 	hours           int
-	project         string
 	worktree        bool
 	debugFlag       bool
 	versionFlag     bool
@@ -81,10 +80,9 @@ func init() {
 	// Disable flag sorting to maintain custom order
 	rootCmd.Flags().SortFlags = false
 
-	// Define flags in desired display order: --days, --hours, --project, --worktree, --help, --version, --debug, --update, --check-update
+	// Define flags in desired display order: --days, --hours, --worktree, --help, --version, --debug, --update, --check-update
 	rootCmd.Flags().IntVarP(&days, "days", "d", 1, "Number of days to look back (default: 1)")
 	rootCmd.Flags().IntVarP(&hours, "hours", "H", 0, "Number of hours to look back (1-24, overrides --days)")
-	rootCmd.Flags().StringVarP(&project, "project", "p", "", "Filter by specific project")
 	rootCmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Show projects as worktree (separate similar repos)")
 	rootCmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "Show version information")
 	rootCmd.Flags().BoolVar(&debugFlag, "debug", false, "Enable debug output for troubleshooting")
@@ -109,15 +107,11 @@ func runMonitor() error {
 	}
 
 	// Display loading message
-	loadingMsg := fmt.Sprintf("Loading Claude sessions from the last %s", timeUnit)
-	if project != "" {
-		loadingMsg += fmt.Sprintf(" (filtered by project: %s)", project)
-	}
-	loadingMsg += "..."
+	loadingMsg := fmt.Sprintf("Loading Claude sessions from the last %s...", timeUnit)
 	fmt.Println(loadingMsg)
 
 	// Load sessions
-	timelines, err := claude.LoadSessionsInTimeRange(startTime, endTime, project, worktree, debugFlag)
+	timelines, err := claude.LoadSessionsInTimeRange(startTime, endTime, worktree, debugFlag)
 	if err != nil {
 		return fmt.Errorf("failed to load sessions: %w", err)
 	}

--- a/internal/claude/parser.go
+++ b/internal/claude/parser.go
@@ -157,7 +157,7 @@ func GetAllSessionFiles() ([]string, error) {
 }
 
 // LoadSessionsInTimeRange loads all Claude sessions within a time range, grouped by project directory
-func LoadSessionsInTimeRange(startTime, endTime time.Time, projectFilter string, threads bool, debug bool) ([]*models.SessionTimeline, error) {
+func LoadSessionsInTimeRange(startTime, endTime time.Time, threads bool, debug bool) ([]*models.SessionTimeline, error) {
 	// Clear repository cache at the start of each execution to avoid stale data
 	repositoryCache = make(map[string]string)
 	if debug {
@@ -191,7 +191,6 @@ func LoadSessionsInTimeRange(startTime, endTime time.Time, projectFilter string,
 		fmt.Printf("DEBUG: Total events parsed: %d\n", len(allEvents))
 		fmt.Printf("DEBUG: Events after time filter: %d\n", len(filteredEvents))
 		fmt.Printf("DEBUG: Time range: %s to %s\n", startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
-		fmt.Printf("DEBUG: Project filter: '%s'\n", projectFilter)
 	}
 
 	// Sort events by timestamp
@@ -203,25 +202,6 @@ func LoadSessionsInTimeRange(startTime, endTime time.Time, projectFilter string,
 	timelines, err := groupEventsByProject(filteredEvents, threads, debug)
 	if err != nil {
 		return nil, err
-	}
-
-	// Apply project filter if specified
-	if projectFilter != "" {
-		var filteredTimelines []*models.SessionTimeline
-		for _, timeline := range timelines {
-			if strings.Contains(strings.ToLower(timeline.ProjectName), strings.ToLower(projectFilter)) {
-				filteredTimelines = append(filteredTimelines, timeline)
-				if debug {
-					fmt.Printf("DEBUG: Timeline '%s' matches filter '%s'\n", timeline.ProjectName, projectFilter)
-				}
-			} else if debug {
-				fmt.Printf("DEBUG: Timeline '%s' does NOT match filter '%s'\n", timeline.ProjectName, projectFilter)
-			}
-		}
-		if debug {
-			fmt.Printf("DEBUG: Total timelines: %d, Filtered timelines: %d\n", len(timelines), len(filteredTimelines))
-		}
-		return filteredTimelines, nil
 	}
 
 	return timelines, nil


### PR DESCRIPTION
## Summary
- Remove --project CLI flag and related code from main.go
- Remove projectFilter parameter from LoadSessionsInTimeRange function 
- Remove project filtering logic from parser.go
- Update documentation in CLAUDE.md to remove --project references

## Test plan
- [x] Build successfully with `make build`
- [x] Help command shows correct flags (no --project flag)
- [x] Application runs without errors using `./bin/ccstat --days 1`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * None.

* **Bug Fixes**
  * None.

* **Documentation**
  * Updated usage examples and feature lists to remove references to the `--project` flag.

* **Refactor**
  * Simplified the command-line interface by removing the `--project` flag and all related project filtering functionality. Users can no longer filter sessions by project from the command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->