### PR TITLE
feat: add --sort option for project timeline sorting

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,10 @@ program
   .option('-H, --hours <number>', 'display activity for the last N hours')
   .option('--worktree', 'display directories separately even within the same repository')
   .option('--color <theme>', 'color theme: blue, green, orange, purple, classic', 'green')
+  .option(
+    '--sort <option>',
+    'sort by: project:asc, project:desc, created:asc, created:desc, events:asc, events:desc, duration:asc, duration:desc'
+  )
   .option('--debug', 'enable debug output')
   .parse(process.argv);
 
@@ -26,6 +30,7 @@ async function main() {
       hours: options.hours ? parseInt(options.hours) : undefined,
       worktree: options.worktree || false,
       color: options.color || 'random',
+      sort: options.sort,
       debug: options.debug || false,
     })
   );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -4,16 +4,18 @@ import { SessionTimeline } from '../models/events';
 import { loadSessionsInTimeRange } from '../core/parser';
 import { ProjectTable } from './ProjectTable';
 import { ColorTheme } from './colorThemes';
+import { SortOption } from '../utils/sort';
 
 interface AppProps {
   days?: number;
   hours?: number;
   worktree: boolean;
   color: ColorTheme;
+  sort?: SortOption;
   debug: boolean;
 }
 
-export const App: React.FC<AppProps> = ({ days = 1, hours, worktree, color }) => {
+export const App: React.FC<AppProps> = ({ days = 1, hours, worktree, color, sort }) => {
   const [timelines, setTimelines] = useState<SessionTimeline[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -52,7 +54,7 @@ export const App: React.FC<AppProps> = ({ days = 1, hours, worktree, color }) =>
 
   return (
     <Box flexDirection="column">
-      <ProjectTable timelines={timelines} days={days} hours={hours} color={color} />
+      <ProjectTable timelines={timelines} days={days} hours={hours} color={color} sort={sort} />
     </Box>
   );
 };

--- a/src/utils/sort.test.ts
+++ b/src/utils/sort.test.ts
@@ -1,0 +1,121 @@
+import { sortTimelines } from './sort';
+import { SessionTimeline } from '../models/events';
+
+describe('sortTimelines', () => {
+  const mockTimelines: SessionTimeline[] = [
+    {
+      projectName: 'Project B',
+      directory: '/path/to/project-b',
+      repository: 'repo-b',
+      events: [],
+      eventCount: 5,
+      activeDuration: 1000,
+      startTime: new Date('2025-01-01T10:00:00Z'),
+      endTime: new Date('2025-01-01T11:00:00Z'),
+    },
+    {
+      projectName: 'Project A',
+      directory: '/path/to/project-a',
+      repository: 'repo-a',
+      events: [],
+      eventCount: 10,
+      activeDuration: 2000,
+      startTime: new Date('2025-01-01T09:00:00Z'),
+      endTime: new Date('2025-01-01T10:00:00Z'),
+    },
+    {
+      projectName: 'Project C',
+      directory: '/path/to/project-c',
+      repository: 'repo-c',
+      events: [],
+      eventCount: 3,
+      activeDuration: 500,
+      startTime: new Date('2025-01-01T11:00:00Z'),
+      endTime: new Date('2025-01-01T12:00:00Z'),
+    },
+  ];
+
+  describe('project name sorting', () => {
+    it('should sort by project name ascending', () => {
+      const result = sortTimelines(mockTimelines, 'project:asc');
+      expect(result[0].projectName).toBe('Project A');
+      expect(result[1].projectName).toBe('Project B');
+      expect(result[2].projectName).toBe('Project C');
+    });
+
+    it('should sort by project name descending', () => {
+      const result = sortTimelines(mockTimelines, 'project:desc');
+      expect(result[0].projectName).toBe('Project C');
+      expect(result[1].projectName).toBe('Project B');
+      expect(result[2].projectName).toBe('Project A');
+    });
+  });
+
+  describe('created time sorting', () => {
+    it('should sort by created time ascending (oldest first)', () => {
+      const result = sortTimelines(mockTimelines, 'created:asc');
+      expect(result[0].projectName).toBe('Project A'); // 09:00
+      expect(result[1].projectName).toBe('Project B'); // 10:00
+      expect(result[2].projectName).toBe('Project C'); // 11:00
+    });
+
+    it('should sort by created time descending (newest first)', () => {
+      const result = sortTimelines(mockTimelines, 'created:desc');
+      expect(result[0].projectName).toBe('Project C'); // 11:00
+      expect(result[1].projectName).toBe('Project B'); // 10:00
+      expect(result[2].projectName).toBe('Project A'); // 09:00
+    });
+  });
+
+  describe('events count sorting', () => {
+    it('should sort by events count ascending', () => {
+      const result = sortTimelines(mockTimelines, 'events:asc');
+      expect(result[0].eventCount).toBe(3);
+      expect(result[1].eventCount).toBe(5);
+      expect(result[2].eventCount).toBe(10);
+    });
+
+    it('should sort by events count descending', () => {
+      const result = sortTimelines(mockTimelines, 'events:desc');
+      expect(result[0].eventCount).toBe(10);
+      expect(result[1].eventCount).toBe(5);
+      expect(result[2].eventCount).toBe(3);
+    });
+  });
+
+  describe('duration sorting', () => {
+    it('should sort by duration ascending', () => {
+      const result = sortTimelines(mockTimelines, 'duration:asc');
+      expect(result[0].activeDuration).toBe(500);
+      expect(result[1].activeDuration).toBe(1000);
+      expect(result[2].activeDuration).toBe(2000);
+    });
+
+    it('should sort by duration descending', () => {
+      const result = sortTimelines(mockTimelines, 'duration:desc');
+      expect(result[0].activeDuration).toBe(2000);
+      expect(result[1].activeDuration).toBe(1000);
+      expect(result[2].activeDuration).toBe(500);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty array', () => {
+      const result = sortTimelines([], 'project:asc');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle single item array', () => {
+      const singleItem = [mockTimelines[0]];
+      const result = sortTimelines(singleItem, 'project:asc');
+      expect(result).toEqual(singleItem);
+    });
+
+    it('should not mutate the original array', () => {
+      const originalOrder = mockTimelines.map(t => t.projectName);
+      sortTimelines(mockTimelines, 'project:asc');
+      const afterSortOrder = mockTimelines.map(t => t.projectName);
+      expect(afterSortOrder).toEqual(originalOrder);
+    });
+  });
+});

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,0 +1,47 @@
+import { SessionTimeline } from '../models/events';
+
+export type SortOption =
+  | 'project:asc'
+  | 'project:desc'
+  | 'created:asc'
+  | 'created:desc'
+  | 'events:asc'
+  | 'events:desc'
+  | 'duration:asc'
+  | 'duration:desc';
+
+export function sortTimelines(
+  timelines: SessionTimeline[],
+  sortOption: SortOption
+): SessionTimeline[] {
+  const sorted = [...timelines];
+
+  switch (sortOption) {
+    case 'project:asc':
+      return sorted.sort((a, b) => a.projectName.localeCompare(b.projectName));
+
+    case 'project:desc':
+      return sorted.sort((a, b) => b.projectName.localeCompare(a.projectName));
+
+    case 'created:asc':
+      return sorted.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+
+    case 'created:desc':
+      return sorted.sort((a, b) => b.startTime.getTime() - a.startTime.getTime());
+
+    case 'events:asc':
+      return sorted.sort((a, b) => a.eventCount - b.eventCount);
+
+    case 'events:desc':
+      return sorted.sort((a, b) => b.eventCount - a.eventCount);
+
+    case 'duration:asc':
+      return sorted.sort((a, b) => a.activeDuration - b.activeDuration);
+
+    case 'duration:desc':
+      return sorted.sort((a, b) => b.activeDuration - a.activeDuration);
+
+    default:
+      return sorted;
+  }
+}


### PR DESCRIPTION
## Summary

- Added `--sort` CLI option with 8 sorting variants: `project:asc`, `project:desc`, `created:asc`, `created:desc`, `events:asc`, `events:desc`, `duration:asc`, `duration:desc`
- Implemented comprehensive test coverage with 11 test cases following TDD approach
- Integrated sorting functionality across CLI, App, and ProjectTable components

## Test plan

- [ ] Test all 8 sort options work correctly
- [ ] Verify help output shows the new option
- [ ] Ensure default behavior (no sort) remains unchanged  
- [ ] Check that sort doesn't mutate original data
- [ ] Verify edge cases (empty arrays, single items) work

🤖 Generated with [Claude Code](https://claude.ai/code)