### PR TITLE
fix: prevent cross-project name pollution in findParentRepository

### DIFF
--- a/src/core/git/index.ts
+++ b/src/core/git/index.ts
@@ -52,17 +52,26 @@ export function getRepositoryName(directory: string): string | null {
 
 function extractRepoNameFromConfig(content: string): string | null {
   const lines = content.split('\n');
+  let inRemoteSection = false;
 
   for (const line of lines) {
     const trimmed = line.trim();
 
-    // Look for URL lines
-    const urlMatch = trimmed.match(/url\s*=\s*(.+)/);
-    if (urlMatch) {
-      const url = urlMatch[1].trim();
-      const repoName = extractRepoNameFromURL(url);
-      if (repoName) {
-        return repoName;
+    // Track section headers — only extract URLs from [remote "..."] sections,
+    // not [submodule "..."] sections whose URLs point to unrelated repos.
+    if (trimmed.startsWith('[')) {
+      inRemoteSection = /^\[remote\s+"/.test(trimmed);
+      continue;
+    }
+
+    if (inRemoteSection) {
+      const urlMatch = trimmed.match(/url\s*=\s*(.+)/);
+      if (urlMatch) {
+        const url = urlMatch[1].trim();
+        const repoName = extractRepoNameFromURL(url);
+        if (repoName) {
+          return repoName;
+        }
       }
     }
   }

--- a/src/core/parser/index.ts
+++ b/src/core/parser/index.ts
@@ -33,7 +33,10 @@ function getCachedRepositoryName(directory: string): string {
   return repoName;
 }
 
-// Find parent repository by walking up the directory tree
+// Find parent repository by walking up the directory tree.
+// Only checks for actual .git/config with remotes — never uses the
+// repositoryCache to avoid cross-project name pollution (e.g. a cached
+// parent "/home/user" → "user" would incorrectly rename unrelated child projects).
 function findParentRepository(directory: string): string | null {
   let currentDir = directory;
 
@@ -44,19 +47,11 @@ function findParentRepository(directory: string): string | null {
       break;
     }
 
-    if (repositoryCache.has(parentDir)) {
-      const repoName = repositoryCache.get(parentDir)!;
-      if (repoName) {
-        repositoryCache.set(directory, repoName);
-        return repoName;
-      }
-    } else {
-      const repoName = getRepositoryName(parentDir);
-      if (repoName) {
-        repositoryCache.set(parentDir, repoName);
-        repositoryCache.set(directory, repoName);
-        return repoName;
-      }
+    const repoName = getRepositoryName(parentDir);
+    if (repoName) {
+      repositoryCache.set(parentDir, repoName);
+      repositoryCache.set(directory, repoName);
+      return repoName;
     }
 
     currentDir = parentDir;


### PR DESCRIPTION
## Summary

Two related bugs in project name resolution cause projects to appear under the wrong name or vanish entirely.

### Bug 1: Cross-project cache pollution in `findParentRepository`

- **Symptom**: Projects randomly disappear when using wider date ranges (e.g. `-d 3` vs `-d 1`)
- **Root cause**: `findParentRepository()` consulted the shared `repositoryCache` when walking parent directories. When project A (e.g. `cwd=/home/user`) was processed first, it cached `/home/user` → `user`. Later, project B (e.g. `cwd=/home/user/Documents/ProjectX`) walked up its parents, hit the cached entry, and inherited the name `user` — merging its events into the wrong timeline
- **Fix**: `findParentRepository()` now only checks for actual `.git/config` with remotes when walking parents, never consulting the shared cache

### Bug 2: Submodule URL extracted instead of remote URL

- **Symptom**: A project appears under its submodule's name instead of its own
- **Root cause**: `extractRepoNameFromConfig()` matched the first `url =` line in `.git/config` regardless of section. When a repo had no `[remote "origin"]` but had `[submodule "foo"]`, the submodule's URL was extracted and used as the project name
- **Fix**: Track section headers and only extract URLs from `[remote "..."]` sections

## Reproduction

### Bug 1
1. Have two projects where one's `cwd` is an ancestor of the other
2. Ensure both have events in a 3-day window but only the child has events in a 1-day window
3. `ccstat -d 1` → child project appears. `ccstat -d 3` → child vanishes, absorbed into parent

### Bug 2
1. Have a project with a git submodule but no remote origin
2. `ccstat` → project appears under the submodule's repo name instead of its own basename

## Test plan

- [x] `ccstat -d 1` and `-d 3` both show all projects with correct names
- [x] Projects with submodules but no remote use their basename, not the submodule name
- [x] Projects with git remotes are still named correctly
- [x] No regressions on event counts or duration calculations

🤖 Generated with [Claude Code](https://claude.com/claude-code)